### PR TITLE
Re-encode instructions into Arviss opcodes.

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -21,6 +21,7 @@ function(add_app NAME)
 endfunction()
 
 add_app(bencher)
+add_app(re-encoder)
 add_app(runner)
 
 add_folders(Apps)

--- a/apps/re-encoder.cpp
+++ b/apps/re-encoder.cpp
@@ -46,7 +46,7 @@ auto main(int argc, char* argv[]) -> int
         Rv32iArvissEncoder encoder{};
 
         // Create a CPU.
-        using Cpu = Rv32imCpuIntegerCore<NoIoMem>;
+        using Cpu = Rv32imfCpuFloatCore<NoIoMem>;
         // using Cpu = Rv32iCpuIntegerCore<BasicMem>;
         static_assert(IsRv32iCpu<Cpu>);
 

--- a/apps/re-encoder.cpp
+++ b/apps/re-encoder.cpp
@@ -11,15 +11,24 @@
 
 using namespace arviss;
 
+using Cache = std::vector<Encoding>;
+
 template<IsRv32iCpu T>
-auto Run(T& t, size_t count) -> void
+auto Run(T& t, size_t count, Cache& cache) -> void
 {
     auto encoder = Rv32iDispatcher<Rv32iArvissEncoder>{};
     while (count > 0 && !t.IsTrapped())
     {
-        auto ins = t.Fetch();                       // Fetch.
-        auto arvissEncoded = encoder.Dispatch(ins); // Convert it into Arviss encoding.
-        t.DispatchEncoded(arvissEncoded);           // Dispatch it as an Arviss encoded instruction.
+        auto pc = t.Transfer();                  // Update pc from nextPc.
+        auto arvissEncoded = cache[pc / 4];      // Look for the instruction in the cache.
+        if (arvissEncoded.opcode == Opcode::Fdx) // Decode it if we don't know about it.
+        {
+            auto ins = t.Fetch32(pc);              // Fetch the RISC-V encoded instruction from memory.
+            arvissEncoded = encoder.Dispatch(ins); // Convert it into Arviss encoding.
+            cache[pc / 4] = arvissEncoded;         // Place it in the cache.
+        }
+        t.SetNextPc(pc + 4);              // Go to the next instruction.
+        t.DispatchEncoded(arvissEncoded); // Dispatch it as an Arviss encoded instruction.
         --count;
     }
 }
@@ -47,8 +56,8 @@ auto main(int argc, char* argv[]) -> int
         Rv32iArvissEncoder encoder{};
 
         // Create a CPU.
-        // using Cpu = Rv32iCpuIntegerCore<NoIoMem>;
-        using Cpu = Rv32iCpuIntegerCore<BasicMem>;
+        using Cpu = Rv32iCpuIntegerCore<NoIoMem>;
+        // using Cpu = Rv32iCpuIntegerCore<BasicMem>;
         static_assert(IsRv32iCpu<Cpu>);
 
         using ArvissEncodedCpu = Arviss32iDispatcher<Cpu>;
@@ -64,12 +73,14 @@ auto main(int argc, char* argv[]) -> int
             ++addr;
         }
 
+        Cache cache(8192);
+
         // Execute some instructions.
         for (int i = 0; i < 100000; i++)
         {
             cpu.ClearTraps();
             cpu.SetNextPc(0);
-            Run(cpu, 1000000);
+            Run(cpu, 1000000, cache);
 
             if (cpu.IsTrapped())
             {

--- a/apps/re-encoder.cpp
+++ b/apps/re-encoder.cpp
@@ -1,0 +1,88 @@
+#include "arviss/common/types.h"         // Address
+#include "arviss/platforms/basic/cpus.h" // BasicRv32imfCpu
+#include "arviss/rv32/arviss_encoder.h"  // Rv32iArvissEncoder
+#include "arviss/rv32/concepts.h"        // IsRv32imfCpu
+
+#include <format>
+#include <fstream>
+#include <iostream>
+#include <vector>
+
+using namespace arviss;
+
+template<IsRv32imfCpu T>
+auto Run(T& t, size_t count) -> void
+{
+    while (count > 0 && !t.IsTrapped())
+    {
+        auto ins = t.Fetch(); // Fetch.
+        t.Dispatch(ins);      // Execute.
+        --count;
+    }
+}
+
+auto main(int argc, char* argv[]) -> int
+{
+    try
+    {
+        if (argc < 2)
+        {
+            std::cerr << "Please supply a filename.";
+            return 2;
+        }
+
+        // Read the image into a buffer.
+        const char* filename = argv[1];
+        std::ifstream fileHandle(filename, std::ios::in | std::ios::binary | std::ios::ate);
+        const std::streampos fileSize = fileHandle.tellg();
+        fileHandle.seekg(0, std::ios::beg);
+        std::vector<u8> buf(static_cast<size_t>(fileSize));
+        fileHandle.read(reinterpret_cast<char*>(buf.data()), fileSize);
+        fileHandle.close();
+
+        // Create an encoder.
+        Rv32iArvissEncoder encoder{};
+
+        // Create a CPU.
+        using Cpu = Rv32imfCpuFloatCore<NoIoMem>;
+        static_assert(IsRv32imfCpu<Cpu>);
+
+        Cpu cpu{};
+
+        // Populate its memory with the contents of the image.
+        Address addr = 0;
+        for (auto b : buf)
+        {
+            cpu.Write8(addr, b);
+            ++addr;
+        }
+
+        // Execute some instructions.
+        for (int i = 0; i < 100000; i++)
+        {
+            cpu.ClearTraps();
+            cpu.SetNextPc(0);
+            Run(cpu, 1000000);
+
+            if (cpu.IsTrapped())
+            {
+                switch (cpu.TrapCause()->type_)
+                {
+                case TrapType::Breakpoint:
+                    break;
+                case TrapType::EnvironmentCallFromMMode:
+                    std::cerr << "ecall from M mode\n";
+                    break;
+                default:
+                    std::cerr << "trapped\n";
+                }
+            }
+        }
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Exited with: " << e.what() << '\n';
+        return 1;
+    }
+    return 0;
+}

--- a/apps/re-encoder.cpp
+++ b/apps/re-encoder.cpp
@@ -16,7 +16,6 @@ using Cache = std::vector<Encoding>;
 template<IsRv32iCpu T>
 auto Run(T& t, size_t count) -> void
 {
-    auto encoder = Rv32iDispatcher<Rv32iArvissEncoder>{};
     while (count > 0 && !t.IsTrapped())
     {
         t.QuickDispatch();

--- a/apps/re-encoder.cpp
+++ b/apps/re-encoder.cpp
@@ -46,7 +46,7 @@ auto main(int argc, char* argv[]) -> int
         Rv32iArvissEncoder encoder{};
 
         // Create a CPU.
-        using Cpu = Rv32iCpuIntegerCore<NoIoMem>;
+        using Cpu = Rv32imCpuIntegerCore<NoIoMem>;
         // using Cpu = Rv32iCpuIntegerCore<BasicMem>;
         static_assert(IsRv32iCpu<Cpu>);
 

--- a/include/arviss/rv32/arviss_encoder.h
+++ b/include/arviss/rv32/arviss_encoder.h
@@ -1,0 +1,249 @@
+#pragma once
+
+#include "arviss/core/concepts.h"
+#include "arviss/rv32/concepts.h"
+
+namespace arviss
+{
+    // Arviss-encode opcodes.
+
+    enum class Opcode
+    {
+        // Arviss.
+        Fdx,
+
+        // --- RV32i
+
+        // Illegal instruction.
+        Illegal,
+        // B-type instructions.
+        Beq,
+        Bne,
+        Blt,
+        Bge,
+        Bltu,
+        Bgeu,
+        // I-type instructions.
+        Lb,
+        Lh,
+        Lw,
+        Lbu,
+        Lhu,
+        Addi,
+        Slti,
+        Sltiu,
+        Xori,
+        Ori,
+        Andi,
+        Jalr,
+        // S-type instructions.
+        Sb,
+        Sh,
+        Sw,
+        // U-type instructions.
+        Auipc,
+        Lui,
+        // J-type instructions.
+        Jal,
+        // Arithmetic instructions.
+        Add,
+        Sub,
+        Sll,
+        Slt,
+        Sltu,
+        Xor,
+        Srl,
+        Sra,
+        Or,
+        And,
+        // Immediate shift instructions.
+        Slli,
+        Srli,
+        Srai,
+        Fence,
+        Ecall,
+        Ebreak,
+
+        // --- RV32m
+        Mul,
+        Mulh,
+        Mulhsu,
+        Mulhu,
+        Div,
+        Divu,
+        Rem,
+        Remu
+    };
+
+    // Illegal instruction.
+    struct IllegalType
+    {
+        u32 ins;
+    };
+
+    // B-type instruction.
+    struct BType
+    {
+        Reg rs1;
+        Reg rs2;
+        u32 bimm;
+    };
+
+    // I-type instruction.
+    struct IType
+    {
+        Reg rd;
+        Reg rs1;
+        u32 iimm;
+    };
+
+    // S-type instruction.
+    struct SType
+    {
+        Reg rs1;
+        Reg rs2;
+        u32 simm;
+    };
+
+    // U-type instruction.
+    struct UType
+    {
+        Reg rd;
+        Reg uimm;
+    };
+
+    // J-type instruction.
+    struct JType
+    {
+        Reg rd;
+        u32 jimm;
+    };
+
+    // Arithmetic instruction.
+    struct ArithType
+    {
+        Reg rd;
+        Reg rs1;
+        Reg rs2;
+    };
+
+    // Immediate shift instruction.
+    struct ImmShiftType
+    {
+        Reg rd;
+        Reg rs1;
+        u32 shamt;
+    };
+
+    // Fence instruction.
+    struct FenceType
+    {
+        u32 fm;
+        Reg rd;
+        Reg rs1;
+    };
+
+    struct Encoding
+    {
+        Opcode opcode;
+        union
+        {
+            IllegalType illegal;
+            BType btype;
+            IType itype;
+            SType stype;
+            UType utype;
+            JType jtype;
+            ArithType arithType;
+            ImmShiftType immShiftType;
+            FenceType fenceType;
+        };
+    };
+
+    // An Rv32i instruction handler that re-encodes instructions for Arviss.
+    class Rv32iArvissEncoder
+    {
+    public:
+        using Item = Encoding;
+
+        // Illegal instruction.
+        auto Illegal(u32 ins) -> Item { return {.opcode = Opcode::Illegal, .illegal = {.ins = ins}}; }
+
+        // B-type instructions.
+        auto Beq(Reg rs1, Reg rs2, u32 bimm) -> Item { return {.opcode = Opcode::Beq, .btype = {.rs1 = rs1, .rs2 = rs2, .bimm = bimm}}; }
+        auto Bne(Reg rs1, Reg rs2, u32 bimm) -> Item { return {.opcode = Opcode::Bne, .btype = {.rs1 = rs1, .rs2 = rs2, .bimm = bimm}}; }
+        auto Blt(Reg rs1, Reg rs2, u32 bimm) -> Item { return {.opcode = Opcode::Blt, .btype = {.rs1 = rs1, .rs2 = rs2, .bimm = bimm}}; }
+        auto Bge(Reg rs1, Reg rs2, u32 bimm) -> Item { return {.opcode = Opcode::Bge, .btype = {.rs1 = rs1, .rs2 = rs2, .bimm = bimm}}; }
+        auto Bltu(Reg rs1, Reg rs2, u32 bimm) -> Item { return {.opcode = Opcode::Bltu, .btype = {.rs1 = rs1, .rs2 = rs2, .bimm = bimm}}; }
+        auto Bgeu(Reg rs1, Reg rs2, u32 bimm) -> Item { return {.opcode = Opcode::Bgeu, .btype = {.rs1 = rs1, .rs2 = rs2, .bimm = bimm}}; }
+
+        // I-type instructions.
+        auto Lb(Reg rd, Reg rs1, u32 iimm) -> Item { return {.opcode = Opcode::Lb, .itype = {.rd = rd, .rs1 = rs1, .iimm = iimm}}; }
+        auto Lh(Reg rd, Reg rs1, u32 iimm) -> Item { return {.opcode = Opcode::Lh, .itype = {.rd = rd, .rs1 = rs1, .iimm = iimm}}; }
+        auto Lw(Reg rd, Reg rs1, u32 iimm) -> Item { return {.opcode = Opcode::Lw, .itype = {.rd = rd, .rs1 = rs1, .iimm = iimm}}; }
+        auto Lbu(Reg rd, Reg rs1, u32 iimm) -> Item { return {.opcode = Opcode::Lbu, .itype = {.rd = rd, .rs1 = rs1, .iimm = iimm}}; }
+        auto Lhu(Reg rd, Reg rs1, u32 iimm) -> Item { return {.opcode = Opcode::Lhu, .itype = {.rd = rd, .rs1 = rs1, .iimm = iimm}}; }
+        auto Addi(Reg rd, Reg rs1, u32 iimm) -> Item { return {.opcode = Opcode::Addi, .itype = {.rd = rd, .rs1 = rs1, .iimm = iimm}}; }
+        auto Slti(Reg rd, Reg rs1, u32 iimm) -> Item { return {.opcode = Opcode::Slti, .itype = {.rd = rd, .rs1 = rs1, .iimm = iimm}}; }
+        auto Sltiu(Reg rd, Reg rs1, u32 iimm) -> Item { return {.opcode = Opcode::Sltiu, .itype = {.rd = rd, .rs1 = rs1, .iimm = iimm}}; }
+        auto Xori(Reg rd, Reg rs1, u32 iimm) -> Item { return {.opcode = Opcode::Xori, .itype = {.rd = rd, .rs1 = rs1, .iimm = iimm}}; }
+        auto Ori(Reg rd, Reg rs1, u32 iimm) -> Item { return {.opcode = Opcode::Ori, .itype = {.rd = rd, .rs1 = rs1, .iimm = iimm}}; }
+        auto Andi(Reg rd, Reg rs1, u32 iimm) -> Item { return {.opcode = Opcode::Andi, .itype = {.rd = rd, .rs1 = rs1, .iimm = iimm}}; }
+        auto Jalr(Reg rd, Reg rs1, u32 iimm) -> Item { return {.opcode = Opcode::Jalr, .itype = {.rd = rd, .rs1 = rs1, .iimm = iimm}}; }
+
+        // S-type instructions.
+        auto Sb(Reg rs1, Reg rs2, u32 simm) -> Item { return {.opcode = Opcode::Sb, .stype = {.rs1 = rs1, .rs2 = rs2, .simm = simm}}; }
+        auto Sh(Reg rs1, Reg rs2, u32 simm) -> Item { return {.opcode = Opcode::Sh, .stype = {.rs1 = rs1, .rs2 = rs2, .simm = simm}}; }
+        auto Sw(Reg rs1, Reg rs2, u32 simm) -> Item { return {.opcode = Opcode::Sw, .stype = {.rs1 = rs1, .rs2 = rs2, .simm = simm}}; }
+
+        // U-type instructions.
+        auto Auipc(Reg rd, u32 uimm) -> Item { return {.opcode = Opcode::Auipc, .utype = {.rd = rd, .uimm = uimm}}; }
+        auto Lui(Reg rd, u32 uimm) -> Item { return {.opcode = Opcode::Lui, .utype = {.rd = rd, .uimm = uimm}}; }
+
+        // J-type instructions.
+        auto Jal(Reg rd, u32 jimm) -> Item { return {.opcode = Opcode::Jal, .jtype = {.rd = rd, .jimm = jimm}}; }
+
+        // Arithmetic instructions.
+        auto Add(Reg rd, Reg rs1, Reg rs2) -> Item { return {.opcode = Opcode::Add, .arithType = {.rd = rd, .rs1 = rs1, .rs2 = rs2}}; }
+        auto Sub(Reg rd, Reg rs1, Reg rs2) -> Item { return {.opcode = Opcode::Sub, .arithType = {.rd = rd, .rs1 = rs1, .rs2 = rs2}}; }
+        auto Sll(Reg rd, Reg rs1, Reg rs2) -> Item { return {.opcode = Opcode::Sll, .arithType = {.rd = rd, .rs1 = rs1, .rs2 = rs2}}; }
+        auto Slt(Reg rd, Reg rs1, Reg rs2) -> Item { return {.opcode = Opcode::Slt, .arithType = {.rd = rd, .rs1 = rs1, .rs2 = rs2}}; }
+        auto Sltu(Reg rd, Reg rs1, Reg rs2) -> Item { return {.opcode = Opcode::Sltu, .arithType = {.rd = rd, .rs1 = rs1, .rs2 = rs2}}; }
+        auto Xor(Reg rd, Reg rs1, Reg rs2) -> Item { return {.opcode = Opcode::Xor, .arithType = {.rd = rd, .rs1 = rs1, .rs2 = rs2}}; }
+        auto Srl(Reg rd, Reg rs1, Reg rs2) -> Item { return {.opcode = Opcode::Srl, .arithType = {.rd = rd, .rs1 = rs1, .rs2 = rs2}}; }
+        auto Sra(Reg rd, Reg rs1, Reg rs2) -> Item { return {.opcode = Opcode::Sra, .arithType = {.rd = rd, .rs1 = rs1, .rs2 = rs2}}; }
+        auto Or(Reg rd, Reg rs1, Reg rs2) -> Item { return {.opcode = Opcode::Or, .arithType = {.rd = rd, .rs1 = rs1, .rs2 = rs2}}; }
+        auto And(Reg rd, Reg rs1, Reg rs2) -> Item { return {.opcode = Opcode::And, .arithType = {.rd = rd, .rs1 = rs1, .rs2 = rs2}}; }
+
+        // Immediate shift instructions.
+
+        auto Slli(Reg rd, Reg rs1, u32 shamt) -> Item { return {.opcode = Opcode::Slli, .immShiftType{.rd = rd, .rs1 = rs1, .shamt = shamt}}; }
+        auto Srli(Reg rd, Reg rs1, u32 shamt) -> Item { return {.opcode = Opcode::Srli, .immShiftType{.rd = rd, .rs1 = rs1, .shamt = shamt}}; }
+        auto Srai(Reg rd, Reg rs1, u32 shamt) -> Item { return {.opcode = Opcode::Srai, .immShiftType{.rd = rd, .rs1 = rs1, .shamt = shamt}}; }
+
+        auto Fence(u32 fm, Reg rd, Reg rs1) -> Item { return {.opcode = Opcode::Fence, .fenceType = {.fm = fm, .rd = rd, .rs1 = rs1}}; }
+        auto Ecall() -> Item { return {.opcode = Opcode::Ecall}; }
+        auto Ebreak() -> Item { return {.opcode = Opcode::Ebreak}; }
+    };
+
+    static_assert(IsRv32iInstructionHandler<Rv32iArvissEncoder>);
+
+    // An Rv32im instruction handler that re-encodes instructions for Arviss.
+    class Rv32imArvissEncoder : public Rv32iArvissEncoder
+    {
+    public:
+        using Item = Rv32iArvissEncoder::Item;
+
+        auto Mul(Reg rd, Reg rs1, Reg rs2) -> Item { return {.opcode = Opcode::Mul, .arithType = {.rd = rd, .rs1 = rs1, .rs2 = rs2}}; }
+        auto Mulh(Reg rd, Reg rs1, Reg rs2) -> Item { return {.opcode = Opcode::Mulh, .arithType = {.rd = rd, .rs1 = rs1, .rs2 = rs2}}; }
+        auto Mulhsu(Reg rd, Reg rs1, Reg rs2) -> Item { return {.opcode = Opcode::Mulhsu, .arithType = {.rd = rd, .rs1 = rs1, .rs2 = rs2}}; }
+        auto Mulhu(Reg rd, Reg rs1, Reg rs2) -> Item { return {.opcode = Opcode::Mulhu, .arithType = {.rd = rd, .rs1 = rs1, .rs2 = rs2}}; }
+        auto Div(Reg rd, Reg rs1, Reg rs2) -> Item { return {.opcode = Opcode::Div, .arithType = {.rd = rd, .rs1 = rs1, .rs2 = rs2}}; }
+        auto Divu(Reg rd, Reg rs1, Reg rs2) -> Item { return {.opcode = Opcode::Divu, .arithType = {.rd = rd, .rs1 = rs1, .rs2 = rs2}}; }
+        auto Rem(Reg rd, Reg rs1, Reg rs2) -> Item { return {.opcode = Opcode::Rem, .arithType = {.rd = rd, .rs1 = rs1, .rs2 = rs2}}; }
+        auto Remu(Reg rd, Reg rs1, Reg rs2) -> Item { return {.opcode = Opcode::Remu, .arithType = {.rd = rd, .rs1 = rs1, .rs2 = rs2}}; }
+    };
+
+    static_assert(IsRv32imInstructionHandler<Rv32imArvissEncoder>);
+
+} // namespace arviss

--- a/include/arviss/rv32/arviss_encoder.h
+++ b/include/arviss/rv32/arviss_encoder.h
@@ -65,6 +65,7 @@ namespace arviss
         Ebreak,
 
         // --- RV32m
+
         Mul,
         Mulh,
         Mulhsu,
@@ -72,7 +73,36 @@ namespace arviss
         Div,
         Divu,
         Rem,
-        Remu
+        Remu,
+
+        // --- Rv32f
+
+        Fmv_x_w,
+        Fclass_s,
+        Fmv_w_x,
+        Fsqrt_s,
+        Fcvt_w_s,
+        Fcvt_wu_s,
+        Fcvt_s_w,
+        Fcvt_s_wu,
+        Fsgnj_s,
+        Fsgnjn_s,
+        Fsgnjx_s,
+        Fmin_s,
+        Fmax_s,
+        Fle_s,
+        Flt_s,
+        Feq_s,
+        Fadd_s,
+        Fsub_s,
+        Fmul_s,
+        Fdiv_s,
+        Flw,
+        Fsw,
+        Fmadd_s,
+        Fmsub_s,
+        Fnmsub_s,
+        Fnmadd_s,
     };
 
     // Illegal instruction.
@@ -143,6 +173,57 @@ namespace arviss
         Reg rs1;
     };
 
+    struct FloatRdRs1
+    {
+        Reg rd;
+        Reg rs1;
+    };
+
+    struct FloatRdRs1Rm
+    {
+        Reg rd;
+        Reg rs1;
+        u32 rm;
+    };
+
+    struct FloatRdRs1Rs2
+    {
+        Reg rd;
+        Reg rs1;
+        Reg rs2;
+    };
+
+    struct FloatRdRs1Rs2Rm
+    {
+        Reg rd;
+        Reg rs1;
+        Reg rs2;
+        u32 rm;
+    };
+
+    struct FloatRdRs1Rs2Rs3Rm
+    {
+        Reg rd;
+        Reg rs1;
+        Reg rs2;
+        Reg rs3;
+        u32 rm;
+    };
+
+    struct FloatRdRs1Imm
+    {
+        Reg rd;
+        Reg rs1;
+        u32 imm;
+    };
+
+    struct FloatRs1Rs2Imm
+    {
+        Reg rs1;
+        Reg rs2;
+        u32 imm;
+    };
+
     struct Encoding
     {
         Opcode opcode;
@@ -157,6 +238,13 @@ namespace arviss
             ArithType arithType;
             ImmShiftType immShiftType;
             FenceType fenceType;
+            FloatRdRs1 floatRdRs1;
+            FloatRdRs1Rm floatRdRs1Rm;
+            FloatRdRs1Rs2 floatRdRs1Rs2;
+            FloatRdRs1Rs2Rm floatRdRs1Rs2Rm;
+            FloatRdRs1Rs2Rs3Rm floatRdRs1Rs2Rs3Rm;
+            FloatRdRs1Imm floatRdRs1Imm;
+            FloatRs1Rs2Imm floatRs1Rs2Imm;
         };
     };
 
@@ -245,5 +333,75 @@ namespace arviss
     };
 
     static_assert(IsRv32imInstructionHandler<Rv32imArvissEncoder>);
+
+    // TODO: consider compact instructions, i.e., RV32c.
+
+    class Rv32imfArvissEncoder : public Rv32imArvissEncoder
+    {
+    public:
+        using Item = Rv32imArvissEncoder::Item;
+
+        auto Fmv_x_w(Reg rd, Reg rs1) -> Item { return {.opcode = Opcode::Fmv_x_w, .floatRdRs1{.rd = rd, .rs1 = rs1}}; }
+        auto Fclass_s(Reg rd, Reg rs1) -> Item { return {.opcode = Opcode::Fclass_s, .floatRdRs1{.rd = rd, .rs1 = rs1}}; }
+        auto Fmv_w_x(Reg rd, Reg rs1) -> Item { return {.opcode = Opcode::Fmv_w_x, .floatRdRs1{.rd = rd, .rs1 = rs1}}; }
+        auto Fsqrt_s(Reg rd, Reg rs1, u32 rm) -> Item { return {.opcode = Opcode::Fsqrt_s, .floatRdRs1Rm{.rd = rd, .rs1 = rs1, .rm = rm}}; }
+        auto Fcvt_w_s(Reg rd, Reg rs1, u32 rm) -> Item { return {.opcode = Opcode::Fcvt_w_s, .floatRdRs1Rm{.rd = rd, .rs1 = rs1, .rm = rm}}; }
+        auto Fcvt_wu_s(Reg rd, Reg rs1, u32 rm) -> Item { return {.opcode = Opcode::Fcvt_wu_s, .floatRdRs1Rm{.rd = rd, .rs1 = rs1, .rm = rm}}; }
+        auto Fcvt_s_w(Reg rd, Reg rs1, u32 rm) -> Item { return {.opcode = Opcode::Fcvt_s_w, .floatRdRs1Rm{.rd = rd, .rs1 = rs1, .rm = rm}}; }
+        auto Fcvt_s_wu(Reg rd, Reg rs1, u32 rm) -> Item { return {.opcode = Opcode::Fcvt_s_wu, .floatRdRs1Rm{.rd = rd, .rs1 = rs1, .rm = rm}}; }
+        auto Fsgnj_s(Reg rd, Reg rs1, Reg rs2) -> Item { return {.opcode = Opcode::Fsgnj_s, .floatRdRs1Rs2{.rd = rd, .rs1 = rs1, .rs2 = rs2}}; }
+        auto Fsgnjn_s(Reg rd, Reg rs1, Reg rs2) -> Item { return {.opcode = Opcode::Fsgnjn_s, .floatRdRs1Rs2{.rd = rd, .rs1 = rs1, .rs2 = rs2}}; }
+        auto Fsgnjx_s(Reg rd, Reg rs1, Reg rs2) -> Item { return {.opcode = Opcode::Fsgnjx_s, .floatRdRs1Rs2{.rd = rd, .rs1 = rs1, .rs2 = rs2}}; }
+        auto Fmin_s(Reg rd, Reg rs1, Reg rs2) -> Item { return {.opcode = Opcode::Fmin_s, .floatRdRs1Rs2{.rd = rd, .rs1 = rs1, .rs2 = rs2}}; }
+        auto Fmax_s(Reg rd, Reg rs1, Reg rs2) -> Item { return {.opcode = Opcode::Fmax_s, .floatRdRs1Rs2{.rd = rd, .rs1 = rs1, .rs2 = rs2}}; }
+        auto Fle_s(Reg rd, Reg rs1, Reg rs2) -> Item { return {.opcode = Opcode::Fle_s, .floatRdRs1Rs2{.rd = rd, .rs1 = rs1, .rs2 = rs2}}; }
+        auto Flt_s(Reg rd, Reg rs1, Reg rs2) -> Item { return {.opcode = Opcode::Flt_s, .floatRdRs1Rs2{.rd = rd, .rs1 = rs1, .rs2 = rs2}}; }
+        auto Feq_s(Reg rd, Reg rs1, Reg rs2) -> Item { return {.opcode = Opcode::Feq_s, .floatRdRs1Rs2{.rd = rd, .rs1 = rs1, .rs2 = rs2}}; }
+
+        auto Fadd_s(Reg rd, Reg rs1, Reg rs2, u32 rm) -> Item
+        {
+            return {.opcode = Opcode::Fadd_s, .floatRdRs1Rs2Rm{.rd = rd, .rs1 = rs1, .rs2 = rs2, .rm = rm}};
+        }
+
+        auto Fsub_s(Reg rd, Reg rs1, Reg rs2, u32 rm) -> Item
+        {
+            return {.opcode = Opcode::Fsub_s, .floatRdRs1Rs2Rm{.rd = rd, .rs1 = rs1, .rs2 = rs2, .rm = rm}};
+        }
+
+        auto Fmul_s(Reg rd, Reg rs1, Reg rs2, u32 rm) -> Item
+        {
+            return {.opcode = Opcode::Fmul_s, .floatRdRs1Rs2Rm{.rd = rd, .rs1 = rs1, .rs2 = rs2, .rm = rm}};
+        }
+
+        auto Fdiv_s(Reg rd, Reg rs1, Reg rs2, u32 rm) -> Item
+        {
+            return {.opcode = Opcode::Fdiv_s, .floatRdRs1Rs2Rm{.rd = rd, .rs1 = rs1, .rs2 = rs2, .rm = rm}};
+        }
+
+        auto Flw(Reg rd, Reg rs1, u32 imm) -> Item { return {.opcode = Opcode::Flw, .floatRdRs1Imm{.rd = rd, .rs1 = rs1, .imm = imm}}; }
+        auto Fsw(Reg rs1, Reg rs2, u32 imm) -> Item { return {.opcode = Opcode::Fsw, .floatRs1Rs2Imm{.rs1 = rs1, .rs2 = rs2, .imm = imm}}; }
+
+        auto Fmadd_s(Reg rd, Reg rs1, Reg rs2, Reg rs3, u32 rm) -> Item
+        {
+            return {.opcode = Opcode::Fmadd_s, .floatRdRs1Rs2Rs3Rm{.rd = rd, .rs1 = rs1, .rs2 = rs2, .rs3 = rs3, .rm = rm}};
+        }
+
+        auto Fmsub_s(Reg rd, Reg rs1, Reg rs2, Reg rs3, u32 rm) -> Item
+        {
+            return {.opcode = Opcode::Fmsub_s, .floatRdRs1Rs2Rs3Rm{.rd = rd, .rs1 = rs1, .rs2 = rs2, .rs3 = rs3, .rm = rm}};
+        }
+
+        auto Fnmsub_s(Reg rd, Reg rs1, Reg rs2, Reg rs3, u32 rm) -> Item
+        {
+            return {.opcode = Opcode::Fnmsub_s, .floatRdRs1Rs2Rs3Rm{.rd = rd, .rs1 = rs1, .rs2 = rs2, .rs3 = rs3, .rm = rm}};
+        }
+
+        auto Fnmadd_s(Reg rd, Reg rs1, Reg rs2, Reg rs3, u32 rm) -> Item
+        {
+            return {.opcode = Opcode::Fnmadd_s, .floatRdRs1Rs2Rs3Rm{.rd = rd, .rs1 = rs1, .rs2 = rs2, .rs3 = rs3, .rm = rm}};
+        }
+    };
+
+    static_assert(IsRv32imfInstructionHandler<Rv32imfArvissEncoder>);
 
 } // namespace arviss

--- a/include/arviss/rv32/arviss_encoder.h
+++ b/include/arviss/rv32/arviss_encoder.h
@@ -5,12 +5,12 @@
 
 namespace arviss
 {
-    // Arviss-encode opcodes.
+    // Arviss-encoded opcodes.
 
     enum class Opcode
     {
         // Arviss.
-        Fdx,
+        Fdx, // (F)etch the RISC-V encoded instruction, (D)ecode it to Arviss encoding, and e(X)ecute it.
 
         // --- RV32i
 
@@ -148,7 +148,7 @@ namespace arviss
     struct UType
     {
         Reg rd;
-        Reg uimm;
+        u32 uimm;
     };
 
     // J-type instruction.

--- a/include/arviss/rv32/arviss_encoder.h
+++ b/include/arviss/rv32/arviss_encoder.h
@@ -16,6 +16,7 @@ namespace arviss
 
         // Illegal instruction.
         Illegal,
+
         // B-type instructions.
         Beq,
         Bne,
@@ -23,6 +24,7 @@ namespace arviss
         Bge,
         Bltu,
         Bgeu,
+
         // I-type instructions.
         Lb,
         Lh,
@@ -36,15 +38,19 @@ namespace arviss
         Ori,
         Andi,
         Jalr,
+
         // S-type instructions.
         Sb,
         Sh,
         Sw,
+
         // U-type instructions.
         Auipc,
         Lui,
+
         // J-type instructions.
         Jal,
+
         // Arithmetic instructions.
         Add,
         Sub,
@@ -56,10 +62,13 @@ namespace arviss
         Sra,
         Or,
         And,
+
         // Immediate shift instructions.
         Slli,
         Srli,
         Srai,
+
+        // System instructions.
         Fence,
         Ecall,
         Ebreak,

--- a/include/arviss/rv32/arviss_executors.h
+++ b/include/arviss/rv32/arviss_executors.h
@@ -1,0 +1,136 @@
+#pragma once
+
+#include "arviss/core/concepts.h"
+#include "arviss/rv32/arviss_encoder.h" // Opcode.
+#include "arviss/rv32/concepts.h"
+#include "arviss/rv32/executors.h"
+
+namespace arviss
+{
+    template<IsRv32iInstructionHandler T>
+    class Arviss32iDispatcher : public T
+    {
+        auto Self() -> T& { return static_cast<T&>(*this); }
+
+    public:
+        using Item = typename T::Item;
+
+        auto DispatchEncoded(const Encoding& e) -> Item
+        {
+            auto& self = Self();
+
+            switch (e.opcode)
+            {
+            // Arviss.
+            case Opcode::Fdx:
+                // TODO: implement Fdx.
+                break;
+
+            // --- RV32i
+
+            // Illegal instruction.
+            case Opcode::Illegal:
+                return self.Illegal(e.illegal.ins);
+
+            // B-type instructions.
+            case Opcode::Beq:
+                return self.Beq(e.btype.rs1, e.btype.rs2, e.btype.bimm);
+            case Opcode::Bne:
+                return self.Bne(e.btype.rs1, e.btype.rs2, e.btype.bimm);
+            case Opcode::Blt:
+                return self.Blt(e.btype.rs1, e.btype.rs2, e.btype.bimm);
+            case Opcode::Bge:
+                return self.Bge(e.btype.rs1, e.btype.rs2, e.btype.bimm);
+            case Opcode::Bltu:
+                return self.Bltu(e.btype.rs1, e.btype.rs2, e.btype.bimm);
+            case Opcode::Bgeu:
+                return self.Bgeu(e.btype.rs1, e.btype.rs2, e.btype.bimm);
+
+            // I-type instructions.
+            case Opcode::Lb:
+                return self.Lb(e.itype.rd, e.itype.rs1, e.itype.iimm);
+            case Opcode::Lh:
+                return self.Lh(e.itype.rd, e.itype.rs1, e.itype.iimm);
+            case Opcode::Lw:
+                return self.Lw(e.itype.rd, e.itype.rs1, e.itype.iimm);
+            case Opcode::Lbu:
+                return self.Lbu(e.itype.rd, e.itype.rs1, e.itype.iimm);
+            case Opcode::Lhu:
+                return self.Lhu(e.itype.rd, e.itype.rs1, e.itype.iimm);
+            case Opcode::Addi:
+                return self.Addi(e.itype.rd, e.itype.rs1, e.itype.iimm);
+            case Opcode::Slti:
+                return self.Slti(e.itype.rd, e.itype.rs1, e.itype.iimm);
+            case Opcode::Sltiu:
+                return self.Sltiu(e.itype.rd, e.itype.rs1, e.itype.iimm);
+            case Opcode::Xori:
+                return self.Xori(e.itype.rd, e.itype.rs1, e.itype.iimm);
+            case Opcode::Ori:
+                return self.Ori(e.itype.rd, e.itype.rs1, e.itype.iimm);
+            case Opcode::Andi:
+                return self.Andi(e.itype.rd, e.itype.rs1, e.itype.iimm);
+            case Opcode::Jalr:
+                return self.Jalr(e.itype.rd, e.itype.rs1, e.itype.iimm);
+
+            // S-type instructions.
+            case Opcode::Sb:
+                return self.Sb(e.stype.rs1, e.stype.rs2, e.stype.simm);
+            case Opcode::Sh:
+                return self.Sh(e.stype.rs1, e.stype.rs2, e.stype.simm);
+            case Opcode::Sw:
+                return self.Sw(e.stype.rs1, e.stype.rs2, e.stype.simm);
+
+            // U-type instructions.
+            case Opcode::Auipc:
+                return self.Auipc(e.utype.rd, e.utype.uimm);
+            case Opcode::Lui:
+                return self.Lui(e.utype.rd, e.utype.uimm);
+
+            // J-type instructions.
+            case Opcode::Jal:
+                return self.Jal(e.jtype.rd, e.jtype.jimm);
+
+            // Arithmetic instructions.
+            case Opcode::Add:
+                return self.Add(e.arithType.rd, e.arithType.rs1, e.arithType.rs2);
+            case Opcode::Sub:
+                return self.Sub(e.arithType.rd, e.arithType.rs1, e.arithType.rs2);
+            case Opcode::Sll:
+                return self.Sll(e.arithType.rd, e.arithType.rs1, e.arithType.rs2);
+            case Opcode::Slt:
+                return self.Slt(e.arithType.rd, e.arithType.rs1, e.arithType.rs2);
+            case Opcode::Sltu:
+                return self.Sltu(e.arithType.rd, e.arithType.rs1, e.arithType.rs2);
+            case Opcode::Xor:
+                return self.Xor(e.arithType.rd, e.arithType.rs1, e.arithType.rs2);
+            case Opcode::Srl:
+                return self.Srl(e.arithType.rd, e.arithType.rs1, e.arithType.rs2);
+            case Opcode::Sra:
+                return self.Sra(e.arithType.rd, e.arithType.rs1, e.arithType.rs2);
+            case Opcode::Or:
+                return self.Or(e.arithType.rd, e.arithType.rs1, e.arithType.rs2);
+            case Opcode::And:
+                return self.And(e.arithType.rd, e.arithType.rs1, e.arithType.rs2);
+
+            // Immediate shift instructions.
+            case Opcode::Slli:
+                return self.Slli(e.immShiftType.rd, e.immShiftType.rs1, e.immShiftType.shamt);
+            case Opcode::Srli:
+                return self.Srli(e.immShiftType.rd, e.immShiftType.rs1, e.immShiftType.shamt);
+            case Opcode::Srai:
+                return self.Srai(e.immShiftType.rd, e.immShiftType.rs1, e.immShiftType.shamt);
+
+            // System instructions.
+            case Opcode::Fence:
+                return self.Fence(e.fenceType.fm, e.fenceType.rd, e.fenceType.rs1);
+            case Opcode::Ecall:
+                return self.Ecall();
+            case Opcode::Ebreak:
+                return self.Ebreak();
+            }
+
+            // Default to an illegal instruction.
+            return self.Illegal(e.illegal.ins);
+        }
+    };
+} // namespace arviss

--- a/include/arviss/rv32/arviss_executors.h
+++ b/include/arviss/rv32/arviss_executors.h
@@ -148,6 +148,48 @@ namespace arviss
             case Opcode::Ebreak:
                 return self.Ebreak();
 
+            // --- RV32m
+            case Opcode::Mul:
+                if constexpr (IsRv32imCpu<T>)
+                {
+                    return self.Mul(e.arithType.rd, e.arithType.rs1, e.arithType.rs2);
+                }
+            case Opcode::Mulh:
+                if constexpr (IsRv32imCpu<T>)
+                {
+                    return self.Mulh(e.arithType.rd, e.arithType.rs1, e.arithType.rs2);
+                }
+            case Opcode::Mulhsu:
+                if constexpr (IsRv32imCpu<T>)
+                {
+                    return self.Mulhsu(e.arithType.rd, e.arithType.rs1, e.arithType.rs2);
+                }
+            case Opcode::Mulhu:
+                if constexpr (IsRv32imCpu<T>)
+                {
+                    return self.Mulhu(e.arithType.rd, e.arithType.rs1, e.arithType.rs2);
+                }
+            case Opcode::Div:
+                if constexpr (IsRv32imCpu<T>)
+                {
+                    return self.Div(e.arithType.rd, e.arithType.rs1, e.arithType.rs2);
+                }
+            case Opcode::Divu:
+                if constexpr (IsRv32imCpu<T>)
+                {
+                    return self.Divu(e.arithType.rd, e.arithType.rs1, e.arithType.rs2);
+                }
+            case Opcode::Rem:
+                if constexpr (IsRv32imCpu<T>)
+                {
+                    return self.Rem(e.arithType.rd, e.arithType.rs1, e.arithType.rs2);
+                }
+            case Opcode::Remu:
+                if constexpr (IsRv32imCpu<T>)
+                {
+                    return self.Remu(e.arithType.rd, e.arithType.rs1, e.arithType.rs2);
+                }
+
             // Default to an illegal instruction.
             default:
                 return self.Illegal(e.illegal.ins);

--- a/include/arviss/rv32/arviss_executors.h
+++ b/include/arviss/rv32/arviss_executors.h
@@ -36,18 +36,17 @@ namespace arviss
 
             switch (e.opcode)
             {
-            // Arviss.
+            // --- Arviss.
             case Opcode::Fdx: {
                 auto ins = self.Fetch32(pc_);                // Fetch the RISC-V encoded instruction from memory.
                 auto arvissEncoded = encoder_.Dispatch(ins); // Encode it for Arviss.
                 cache_[pc_ / 4] = arvissEncoded;             // Cache it.
 
-                // Doesn't recurse, because we'll get an illegal instruction for anything that the encode doesn't know about.
+                // Doesn't recurse, because we'll get an illegal instruction for anything that the encoder didn't know about.
                 return DispatchEncoded(arvissEncoded);
             }
 
-            // --- RV32i
-
+            // --- RV32i.
             // Illegal instruction.
             case Opcode::Illegal:
                 return self.Illegal(e.illegal.ins);
@@ -148,7 +147,8 @@ namespace arviss
             case Opcode::Ebreak:
                 return self.Ebreak();
 
-            // --- RV32m
+            // --- RV32m.
+            // Integer multiply and divide instructions.
             case Opcode::Mul:
                 if constexpr (IsRv32imCpu<T>)
                 {
@@ -188,6 +188,143 @@ namespace arviss
                 if constexpr (IsRv32imCpu<T>)
                 {
                     return self.Remu(e.arithType.rd, e.arithType.rs1, e.arithType.rs2);
+                }
+
+            // --- RV32f.
+            // Floating point instructions.
+            case Opcode::Fmv_x_w:
+                if constexpr (IsRv32imfCpu<T>)
+                {
+                    return self.Fmv_x_w(e.floatRdRs1.rd, e.floatRdRs1.rs1);
+                }
+            case Opcode::Fclass_s:
+                if constexpr (IsRv32imfCpu<T>)
+                {
+                    return self.Fclass_s(e.floatRdRs1.rd, e.floatRdRs1.rs1);
+                }
+            case Opcode::Fmv_w_x:
+                if constexpr (IsRv32imfCpu<T>)
+                {
+                    return self.Fmv_w_x(e.floatRdRs1.rd, e.floatRdRs1.rs1);
+                }
+            case Opcode::Fsqrt_s:
+                if constexpr (IsRv32imfCpu<T>)
+                {
+                    return self.Fsqrt_s(e.floatRdRs1Rm.rd, e.floatRdRs1Rm.rs1, e.floatRdRs1Rm.rm);
+                }
+            case Opcode::Fcvt_w_s:
+                if constexpr (IsRv32imfCpu<T>)
+                {
+                    return self.Fcvt_w_s(e.floatRdRs1Rm.rd, e.floatRdRs1Rm.rs1, e.floatRdRs1Rm.rm);
+                }
+            case Opcode::Fcvt_wu_s:
+                if constexpr (IsRv32imfCpu<T>)
+                {
+                    return self.Fcvt_wu_s(e.floatRdRs1Rm.rd, e.floatRdRs1Rm.rs1, e.floatRdRs1Rm.rm);
+                }
+            case Opcode::Fcvt_s_w:
+                if constexpr (IsRv32imfCpu<T>)
+                {
+                    return self.Fcvt_s_w(e.floatRdRs1Rm.rd, e.floatRdRs1Rm.rs1, e.floatRdRs1Rm.rm);
+                }
+            case Opcode::Fcvt_s_wu:
+                if constexpr (IsRv32imfCpu<T>)
+                {
+                    return self.Fcvt_s_wu(e.floatRdRs1Rm.rd, e.floatRdRs1Rm.rs1, e.floatRdRs1Rm.rm);
+                }
+            case Opcode::Fsgnj_s:
+                if constexpr (IsRv32imfCpu<T>)
+                {
+                    return self.Fsgnj_s(e.floatRdRs1Rs2.rd, e.floatRdRs1Rs2.rs1, e.floatRdRs1Rs2.rs2);
+                }
+            case Opcode::Fsgnjn_s:
+                if constexpr (IsRv32imfCpu<T>)
+                {
+                    return self.Fsgnjn_s(e.floatRdRs1Rs2.rd, e.floatRdRs1Rs2.rs1, e.floatRdRs1Rs2.rs2);
+                }
+            case Opcode::Fsgnjx_s:
+                if constexpr (IsRv32imfCpu<T>)
+                {
+                    return self.Fsgnjx_s(e.floatRdRs1Rs2.rd, e.floatRdRs1Rs2.rs1, e.floatRdRs1Rs2.rs2);
+                }
+            case Opcode::Fmin_s:
+                if constexpr (IsRv32imfCpu<T>)
+                {
+                    return self.Fmin_s(e.floatRdRs1Rs2.rd, e.floatRdRs1Rs2.rs1, e.floatRdRs1Rs2.rs2);
+                }
+            case Opcode::Fmax_s:
+                if constexpr (IsRv32imfCpu<T>)
+                {
+                    return self.Fmax_s(e.floatRdRs1Rs2.rd, e.floatRdRs1Rs2.rs1, e.floatRdRs1Rs2.rs2);
+                }
+            case Opcode::Fle_s:
+                if constexpr (IsRv32imfCpu<T>)
+                {
+                    return self.Fle_s(e.floatRdRs1Rs2.rd, e.floatRdRs1Rs2.rs1, e.floatRdRs1Rs2.rs2);
+                }
+            case Opcode::Flt_s:
+                if constexpr (IsRv32imfCpu<T>)
+                {
+                    return self.Flt_s(e.floatRdRs1Rs2.rd, e.floatRdRs1Rs2.rs1, e.floatRdRs1Rs2.rs2);
+                }
+            case Opcode::Feq_s:
+                if constexpr (IsRv32imfCpu<T>)
+                {
+                    return self.Feq_s(e.floatRdRs1Rs2.rd, e.floatRdRs1Rs2.rs1, e.floatRdRs1Rs2.rs2);
+                }
+            case Opcode::Fadd_s:
+                if constexpr (IsRv32imfCpu<T>)
+                {
+                    return self.Fadd_s(e.floatRdRs1Rs2Rm.rd, e.floatRdRs1Rs2Rm.rs1, e.floatRdRs1Rs2Rm.rs2, e.floatRdRs1Rs2Rm.rm);
+                }
+            case Opcode::Fsub_s:
+                if constexpr (IsRv32imfCpu<T>)
+                {
+                    return self.Fsub_s(e.floatRdRs1Rs2Rm.rd, e.floatRdRs1Rs2Rm.rs1, e.floatRdRs1Rs2Rm.rs2, e.floatRdRs1Rs2Rm.rm);
+                }
+            case Opcode::Fmul_s:
+                if constexpr (IsRv32imfCpu<T>)
+                {
+                    return self.Fmul_s(e.floatRdRs1Rs2Rm.rd, e.floatRdRs1Rs2Rm.rs1, e.floatRdRs1Rs2Rm.rs2, e.floatRdRs1Rs2Rm.rm);
+                }
+            case Opcode::Fdiv_s:
+                if constexpr (IsRv32imfCpu<T>)
+                {
+                    return self.Fdiv_s(e.floatRdRs1Rs2Rm.rd, e.floatRdRs1Rs2Rm.rs1, e.floatRdRs1Rs2Rm.rs2, e.floatRdRs1Rs2Rm.rm);
+                }
+            case Opcode::Flw:
+                if constexpr (IsRv32imfCpu<T>)
+                {
+                    return self.Flw(e.floatRdRs1Imm.rd, e.floatRdRs1Imm.rs1, e.floatRdRs1Imm.imm);
+                }
+            case Opcode::Fsw:
+                if constexpr (IsRv32imfCpu<T>)
+                {
+                    return self.Fsw(e.floatRs1Rs2Imm.rs1, e.floatRs1Rs2Imm.rs2, e.floatRs1Rs2Imm.imm);
+                }
+            case Opcode::Fmadd_s:
+                if constexpr (IsRv32imfCpu<T>)
+                {
+                    return self.Fmadd_s(e.floatRdRs1Rs2Rs3Rm.rd, e.floatRdRs1Rs2Rs3Rm.rs1, e.floatRdRs1Rs2Rs3Rm.rs2, e.floatRdRs1Rs2Rs3Rm.rs3,
+                                        e.floatRdRs1Rs2Rs3Rm.rm);
+                }
+            case Opcode::Fmsub_s:
+                if constexpr (IsRv32imfCpu<T>)
+                {
+                    return self.Fmsub_s(e.floatRdRs1Rs2Rs3Rm.rd, e.floatRdRs1Rs2Rs3Rm.rs1, e.floatRdRs1Rs2Rs3Rm.rs2, e.floatRdRs1Rs2Rs3Rm.rs3,
+                                        e.floatRdRs1Rs2Rs3Rm.rm);
+                }
+            case Opcode::Fnmsub_s:
+                if constexpr (IsRv32imfCpu<T>)
+                {
+                    return self.Fnmsub_s(e.floatRdRs1Rs2Rs3Rm.rd, e.floatRdRs1Rs2Rs3Rm.rs1, e.floatRdRs1Rs2Rs3Rm.rs2, e.floatRdRs1Rs2Rs3Rm.rs3,
+                                         e.floatRdRs1Rs2Rs3Rm.rm);
+                }
+            case Opcode::Fnmadd_s:
+                if constexpr (IsRv32imfCpu<T>)
+                {
+                    return self.Fnmadd_s(e.floatRdRs1Rs2Rs3Rm.rd, e.floatRdRs1Rs2Rs3Rm.rs1, e.floatRdRs1Rs2Rs3Rm.rs2, e.floatRdRs1Rs2Rs3Rm.rs3,
+                                         e.floatRdRs1Rs2Rs3Rm.rm);
                 }
 
             // Default to an illegal instruction.

--- a/include/arviss/rv32/executors.h
+++ b/include/arviss/rv32/executors.h
@@ -378,8 +378,6 @@ namespace arviss
     public:
         using Item = typename Rv32iIntegerCoreExecutor<T>::Item;
 
-        // TODO: Implement the 'M' extension.
-
         auto Mul(Reg rd, Reg rs1, Reg rs2) -> Item
         {
             // rd <- rs1 * rs2, pc += 4


### PR DESCRIPTION
This PR re-encodes instructions into Arviss opcodes to eliminate the decoding overhead. This gives it a ~2.5x speedup compared with decoding every time.